### PR TITLE
Commits for snmptrap.rb

### DIFF
--- a/snmptrap.rb
+++ b/snmptrap.rb
@@ -79,6 +79,7 @@ class LogStash::Outputs::Snmptrap < LogStash::Outputs::Base
    finished
    return
   end
+  @oid = event.sprintf(@oid)
   @codec.encode(event)
  end
 end

--- a/snmptrap.rb
+++ b/snmptrap.rb
@@ -59,7 +59,7 @@ class LogStash::Outputs::Snmptrap < LogStash::Outputs::Base
    trapsender_opts = {:trap_port => @port, :host => @host, :community => @community }
 
    #check for and add user specified mibs
-   if !@yaml_mibs.empty?
+   if @yaml_mibs && !@yaml_mibs.empty?
     trapsender_opts.merge!({:mib_dir => @yamlmibdir, :mib_modules => @yaml_mibs})
    end
    #prep and do the full send


### PR DESCRIPTION
Hello

I have added two changes to your code.

With the first commit 2953809 it is possible to leave the parameter yamllibdir away. In this case, the mibs of the snmp gem will be taken. Without the change the code will fail, because @yaml_mibs is not an object.

With the second commit 0b0286b it is possible to have a dynamic OID in the snmptrap:
output {
  snmptrap {
    ...
    oid => "%{oid}"
  }
}

Does the changes make sense to you?
Thanks for looking at it.

Best regards
Elmar
